### PR TITLE
server_version setable as key for dowload_url

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.33"
+      #version = "~> 4.33"
     }
   }
 }
@@ -91,7 +91,7 @@ resource "aws_instance" "minecraft" {
     "scripts/startup.sh",
     {
       agent_config = templatefile("scripts/cloudwatch_agent_config.json", { log_group_name = aws_cloudwatch_log_group.minecraft.name })
-      download_url = var.download_url,
+      download_url = var.download_url[var.server_version],
       service      = file("scripts/minecraft.service")
     }
   )

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      #version = "~> 4.33"
+      version = "~> 4.33"
     }
   }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,15 @@
+ec2_instance_connect = false
+
+download_url = {
+    "1.19.3" = "https://piston-data.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar"
+
+    "1.19.2" = "next url"
+}
+
+server_version = "1.19.3"
+
+instance_type = "t2.medium"
+
+region = "eu-west-2"
+
+static_ip = false

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,18 @@ variable "ec2_instance_connect" {
 }
 
 variable "download_url" {
+  type        = map
+  default = {
+    "1.19.3" = "https://piston-data.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar"
+    "1.19.2" = "next url"
+  }
+  description = "Minecraft server versions and download links in a map"
+}
+
+variable "server_version" {
   type        = string
-  default     = "https://piston-data.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar"
-  description = "Minecraft server download URL"
+  default = "1.19.3"
+  description = "Minecraft server version"
 }
 
 variable "instance_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,38 +1,29 @@
 variable "ec2_instance_connect" {
   type        = bool
-  default     = false
   description = "Keep SSH (port 22) open to allow connections via EC2 Instance Connect."
 }
 
 variable "download_url" {
   type        = map
-  default = {
-    "1.19.3" = "https://piston-data.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar"
-    "1.19.2" = "next url"
-  }
   description = "Minecraft server versions and download links in a map"
 }
 
 variable "server_version" {
   type        = string
-  default = "1.19.3"
   description = "Minecraft server version"
 }
 
 variable "instance_type" {
   type        = string
-  default     = "t2.medium"
   description = "The EC2 instance type of the server. Requires at least t2.medium."
 }
 
 variable "region" {
   type        = string
-  default     = "eu-west-2"
   description = "AWS region to deploy to"
 }
 
 variable "static_ip" {
   type        = bool
-  default     = false
   description = "Should the instance retain its IPv4 address after being stopped? Charges apply while the server is stopped."
 }


### PR DESCRIPTION
Hello

**main.tf:**
line5: commented out. Is that a right version number?
line94: download urls are in a map. server version is usable as key to fetch the proper download link.

**variables.tf**
download_url became a map where keys are version numbers and values are download links.
server_version is the key to find the right download link.


I was not able to find **official** location to download older version of Minecraft serves.
I bet you know that but ssh access not configured for its security group.
I would like to mention that the server's interface directly connected to the internet which (as I know) is not a good practice, because of security reasons.

b.
